### PR TITLE
Add quotes around etag value to match S3 responses. Without this tools (...

### DIFF
--- a/drivers/fs/blob_fs.js
+++ b/drivers/fs/blob_fs.js
@@ -669,7 +669,7 @@ FS_blob.prototype.file_create_meta = function (container_name, filename, temp_pa
     }
     fb.logger.debug( ("Created meta for file "+filename+" in container_name "+container_name));
     var header = common_header();
-    header.ETag = opt.vblob_file_etag;
+    header.ETag = '"'+opt.vblob_file_etag+'"';
     resp.resp_code = 200; resp.resp_body = null;
     fb.logger.debug( ('is_copy: ' + is_copy));
     if (is_copy) {
@@ -974,14 +974,14 @@ FS_blob.prototype.file_read = function (container_name, filename, options, callb
         etag_none_match && etag_none_match === obj.vblob_file_etag)
     {
       error_msg(304,'NotModified','The object is not modified',resp);
-      resp.resp_header.etag = obj.vblob_file_etag; resp.resp_header["last-modified"] = obj.vblob_update_time;
+      resp.resp_header.etag = '"'+obj.vblob_file_etag+'"'; resp.resp_header["last-modified"] = obj.vblob_update_time;
       callback(resp.resp_code, resp.resp_header, /*resp.resp_body*/ null, null); //304 should not have body
       return;
     }
     header["content-type"] = obj["content-type"] ? obj["content-type"] :  "binary/octet-stream";
     header["Content-Length"] = obj.vblob_file_size;
     header["Last-Modified"] = obj.vblob_update_time;
-    header.ETag = obj.vblob_file_etag;
+    header.ETag = '"'+obj.vblob_file_etag+'"';
     var keys = Object.keys(obj);
     for (var idx = 0; idx < keys.length; idx++) {
       var obj_key = keys[idx];


### PR DESCRIPTION
...e.g. AWS CLI) break when GETting objects (and when processing the response after creating the object).
